### PR TITLE
README and the changes/fixes to make it accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ log class: Loggerator  #=> app=myapp class=Loggerator
 
 Sometimes you want to log the class/module name for every log message.  Loggerator can log these as "namespaces".  An example we use is for a set of similar subclasses without needing to distinguish between them.
 
-You will need to `include Loggerator::Namespace` on the class/moduleyou want to add a namespace.  Subclasses will inherit namespace logging.
+You will need to `include Loggerator::Namespace` on the class/module you want to add a namespace.  Subclasses will inherit namespace logging.
 
 For example, if we have a set of Mediators:
 ```ruby

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Generate an initializer file:
 rails g loggerator:log
 ```
 
-This will use your rails name by default, if you want use a different name for your default log context you can specify it at generation:
+This will use your rails project name by default. If you want use a different name for your default log context you can specify it at generation:
 
 ```bash
 rails g loggerator:log -a myapp
@@ -70,12 +70,12 @@ Loggerator::Log.default_context = { app: Config.app_name }
 ### Metrics Integration
 
 When including metrics, these will be added to the log items available:
-* It adds metrics helpers along-side the log-helpers
+* It adds metrics helpers alongside the log helpers
 * It will setup your default log context in an initalizer
 
 #### Metrics Helper
 
-Currently, the only metrics integration is written for [l2met](https://github.com/ryandotsmith/l2met)
+Currently, the only metrics integration is written for [l2met](https://github.com/ryandotsmith/l2met).
 
 Amend your Gemfile to include the l2met integration:
 ```ruby
@@ -123,7 +123,7 @@ require 'loggerator/namespace'
 ```
 
 This allows you to add namespaces to logs for modules/classes that include
-Loggerator::Namespace.
+`Loggerator::Namespace`.
 
 ## Usage
 
@@ -132,15 +132,17 @@ Logs are sent to `stdout` and `stderr` as a stream to follow the [12factor](http
 Assume that the following examples have the following configuration:
 
 ```ruby
-Loggerator.default_context = 'myapp'
-Loggerator::Metrics.name = 'myapp'
+Loggerator::Log.default_context = { app: 'myapp' }
+Loggerator::Metrics.name        = 'myapp'
 ```
 
 ### Log Helpers
 
 #### `log`
 
-Use `log` to log any key-value pairs, they can be any value.  Logs are sent to `stdout` by default
+Use `log` to log any key-value pairs, they can be any value.
+
+Logs are sent to `stdout` by default
 
 ```ruby
 log test1: "first", test2: 123  #=> app=myapp test1=first test2=123
@@ -169,7 +171,7 @@ end
 
 #### `log_context`
 
-You can use `log_context` to add values to all encompassing `log` commands
+You can use `log_context` to add values to all encompassed `log` commands
 
 ```ruby
 log_context group: "test_method" do
@@ -184,7 +186,9 @@ end
 
 #### `log_error`
 
-Log exception information using `log_error`.  It will log the class, message, and backtrace.  Every frame of the backtrace will be logged on its own line and is reverse-ordered so that the most relevant stack frames are last. All the logs will be tied together by a common `exception_id`.  Errors logs are sent to `stderr` by default.
+Log exception information using `log_error`.  It will log the class, message, and backtrace.  Every frame of the backtrace will be logged on its own line and is reverse-ordered so that the most relevant stack frames are last. All the logs will be tied together by a common `exception_id`.
+
+Errors logs are sent to `stderr` by default.
 
 ```ruby
 def emit_error
@@ -210,7 +214,7 @@ log_error $!, try: 2
 
 #### Strings
 
-Loggerator will handle strings sanely by wrapping in quotes:
+Loggerator will handle strings sanely by wrapping in quotes when needed:
 
 ```ruby
 log no_spaces: "first", spaces: "second test"
@@ -271,14 +275,14 @@ log summation: -> { 3 + 2 + 1 }  #=> app=myapp summation=6
 Everything else will not transformed by formatting rules will be logged by running `to_s` on the object.
 
 ```ruby
-log class: Loggerator  #=> app=myapp  class=Loggerator
+log class: Loggerator  #=> app=myapp class=Loggerator
 ```
 
 ### Namespace
 
-Sometimes you want to log the Class name for every log message.  Loggerator calls these Namespaces.  An example we use is for a set of similar subclasses without needing to distinguish between them.
+Sometimes you want to log the class/module name for every log message.  Loggerator can log these as "namespaces".  An example we use is for a set of similar subclasses without needing to distinguish between them.
 
-Next, you will need to `include Loggerator::Namespace` on the class (and its subclasses) you want to add a Namespace.
+You will need to `include Loggerator::Namespace` on the class/moduleyou want to add a namespace.  Subclasses will inherit namespace logging.
 
 For example, if we have a set of Mediators:
 ```ruby
@@ -312,7 +316,9 @@ UpdateMediator.run  #=> app=myapp ns=UpdateMediator call
 
 ### Metrics
 
-Metrics uses the [l2met](https://github.com/ryandotsmith/l2met/wiki/Usage) convention to log `count`, `sample`, `measure`, and `unique` using the `m` helper.  It uses the name set in configuration or it will use "loggerator".  These metrics are sent to `stdout` by default.
+Metrics uses the [l2met](https://github.com/ryandotsmith/l2met/wiki/Usage) convention to log `count`, `sample`, `measure`, and `unique` using the `m` helper.  It uses the name set in configuration.  If it is not set, it will use "loggerator".
+
+These metrics are sent to `stdout` by default.
 
 ```ruby
 m.count(:clicks)                          #=> app=myapp count#myapp.clicks=1

--- a/README.md
+++ b/README.md
@@ -1,39 +1,405 @@
 # loggerator
 
+Provides a simple logging mechanism that will generate logs in a `key=value` style.
+
+> This was adapted from the configuration implementation in [Pliny](https://github.com/interagent/pliny).
+
+Loggerator offers the following functionality:
+
+* Simle `log` helpers
+* RequestID genration, chaining
+* Rails Integration
+* Simple `metrics` helpers for l2met
+
+## Installation
+
+Add this to your application's Gemfile:
+```ruby
+gem 'loggerator'
+```
+
+Then, execute:
+```bash
+$ bundle
+```
+
+Or install it yourself:
+```bash
+$ gem install loggerator
+```
+
+### Rails Integration
+
+Loggerator offers integration points for the Rails framework.
+* It adds log helpers to ActionView, ActiveRecord, ActionController, and ActionMailer
+* It will setup your default log context in an initalizer
+
+#### Log Helpers
+
+Amend your Gemfile to include the Rails integration:
+```ruby
+gem "loggerator", require: "loggerator/rails"
+```
+
+Then, execute:
+```bash
+$ bundle
+```
+
+This adds `log`, `log_error`, `log_context` to the class and instance methods for ActionView, ActiveRecord, ActionController, and ActionMailer.
+
+#### Initializer
+
+Generate an initializer file:
+```bash
+rails g loggerator:log
+```
+
+This will use your rails name by default, if you want use a different name for your default log context you can specify it at generation:
+
+```bash
+rails g loggerator:log -a myapp
+```
+
+Or you can set it manually or through configuration in the generated initialization file `config/initializers/log.rb`. For example:
+
+```ruby
+Loggerator::Log.default_context = { app: Config.app_name }
+```
+
+### Metrics Integration
+
+When including metrics, these will be added to the log items available:
+* It adds metrics helpers along-side the log-helpers
+* It will setup your default log context in an initalizer
+
+#### Metrics Helper
+
+Currently, the only metrics integration is written for [l2met](https://github.com/ryandotsmith/l2met)
+
+Amend your Gemfile to include the l2met integration:
+```ruby
+gem "loggerator", require: ["loggerator/rails", "loggerator/metrics"]
+```
+
+Or require it yourself:
+```bash
+require 'loggerator/metrics'
+```
+
+This adds the `m` helper to the class and instance methods for ActionView, ActiveRecord, ActionController, and ActionMailer.
+
+#### Initializer
+
+If you have setup Loggerator to require Metrics before generating an initializer, Metrics configuration will be included.
+
+Generate an initializer file:
+```bash
+rails g loggerator:log
+```
+
+This will use your rails name by default, if you want use a different name for your default log context you can specify it at generation:
+
+```bash
+rails g loggerator:log -a myapp
+```
+
+Or you can set it manually or through configuration in the generated initialization file `config/initializers/log.rb`. For example:
+
+```ruby
+Loggerator::Metrics.name = Config.app_name
+```
+
+### Namespaces
+
+To use Namespaces, you need to make sure to amend your Gemfile:
+```ruby
+gem "loggerator", require: 'loggerator/namespace'
+```
+
+Or require it yourself:
+```bash
+require 'loggerator/namespace'
+```
+
+This allows you to add namespaces to logs for modules/classes that include
+Loggerator::Namespace.
+
 ## Usage
 
-### Rails
+Logs are sent to `stdout` and `stderr` as a stream to follow the [12factor](https://12factor.net/logs) methodology.  This can be altered through configuration.
+
+Assume that the following examples have the following configuration:
 
 ```ruby
-TODO
+Loggerator.default_context = 'myapp'
+Loggerator::Metrics.name = 'myapp'
 ```
 
-### Pure Ruby
+### Log Helpers
 
-**As a module**
+#### `log`
+
+Use `log` to log any key-value pairs, they can be any value.  Logs are sent to `stdout` by default
 
 ```ruby
-TODO
+log test1: "first", test2: 123  #=> app=myapp test1=first test2=123
 ```
 
-**Included**
+Use blocks to emit timing information, assuming `test_method` does the following:
+```
+def test_method
+  log(sleep: 0.4)
+  sleep(0.4)
+end
+```
+
+Then you can see actual timing with:
 
 ```ruby
-TODO
+log timing: "test_method" do
+  test_method
+  log success: true
+end
+#=> app=myapp timing=test_method at=start
+#=> app=myapp sleep: 0.400
+#=> app=myapp success
+#=> app=myapp timing=test_method at=finish elapsed=0.401
 ```
 
-## Development
+#### `log_context`
 
-### Testing
+You can use `log_context` to add values to all encompassing `log` commands
 
+```ruby
+log_context group: "test_method" do
+  log try: 1
+  test_method
+  log success: true
+end
+#=> app=myapp group=test_method try=1
+#=> app=myapp group=test_method sleep: 0.400
+#=> app=myapp group=test_method success
 ```
-# w/ docker
-$ docker-compose --rm test
 
-# w/o docker
-$ make
+#### `log_error`
 
-# w/o make and docker
-$ bundle install
-$ bundle exec rake test
+Log exception information using `log_error`.  It will log the class, message, and backtrace.  Every frame of the backtrace will be logged on its own line and is reverse-ordered so that the most relevant stack frames are last. All the logs will be tied together by a common `exception_id`.  Errors logs are sent to `stderr` by default.
+
+```ruby
+def emit_error
+  raise "this is an error"
+rescue
+  log_error $!
+end
+
+emit_error
+#=> app=myapp exception_id=70113140892880 backtrace="(pry):64:in `<main>'"
+#=> app=myapp exception_id=70113140892880 backtrace="(pry):53:in `emit_error'"
+#=> app=myapp exception_id=70113140892880 exception class=RuntimeError message="this is an error"
 ```
+
+You can add additional key-value pairs to `log_error`
+
+```ruby
+log_error $!, try: 2
+#=> app=myapp exception_id=70113140892880 exception class=RuntimeError message="this is an error" try=2
+```
+
+### Formatting Rules
+
+#### Strings
+
+Loggerator will handle strings sanely by wrapping in quotes:
+
+```ruby
+log no_spaces: "first", spaces: "second test"
+#=> app=myapp no_spaces=first spaces="second test"
+```
+
+And handles embedded quotes:
+```ruby
+log double: %q[test with a "double-quote"], single: %q[test with a 'single-quote']
+#=> app=myapp double='test with a "double-quote"' single="test with a 'single-quote'"
+
+log embedded_quotes: %q[test with a "double-quote with a 'single-quote' inside"]
+#=> app=myapp embedded_quotes="test with a \"double-quote with a 'single-quote' inside\""
+```
+
+#### Numbers
+
+Floats will be formatted to three digits of precision, all other numbers will be shown as-is.
+
+```ruby
+log pi: 3.14159, integer: 123456789  #=> app=myapp pi=3.142 integer=123456789"
+```
+
+#### Booleans
+
+True values will only show the key, false values are shown as is.
+
+```ruby
+log on: true, off: false  #=> app=myapp on off=false"
+```
+
+#### Nil
+
+Nil values will be removed
+
+```ruby
+log removed: nil  #=> app=myapp"
+```
+
+#### Time
+
+Time will be formatted using [iso8601](http://ruby-doc.org/stdlib-2.3.1/libdoc/date/rdoc/Date.html#method-c-iso8601) format
+
+```ruby
+log time: Time.now  #=> app=myapp  time=2016-10-10T16:13:29-07:00"
+```
+
+#### Procs
+
+Procs will be executed, their results will follow the formatting rules above.
+
+```ruby
+log summation: -> { 3 + 2 + 1 }  #=> app=myapp summation=6
+```
+
+#### Default
+
+Everything else will not transformed by formatting rules will be logged by running `to_s` on the object.
+
+```ruby
+log class: Loggerator  #=> app=myapp  class=Loggerator
+```
+
+### Namespace
+
+Sometimes you want to log the Class name for every log message.  Loggerator calls these Namespaces.  An example we use is for a set of similar subclasses without needing to distinguish between them.
+
+Next, you will need to `include Loggerator::Namespace` on the class (and its subclasses) you want to add a Namespace.
+
+For example, if we have a set of Mediators:
+```ruby
+class Mediator
+  def self.run
+    new.call
+  end
+end
+
+class CreateMediator < Mediator
+  def call
+    log call: true
+    # do a thing
+  end
+end
+
+class UpdateMediator < Mediator
+  def call
+    log call: true
+    # do a thing
+  end
+end
+```
+
+When you run each of these mediators, it will log a new `ns` key-value pair:
+
+```ruby
+CreateMediator.run  #=> app=myapp ns=CreateMediator call
+UpdateMediator.run  #=> app=myapp ns=UpdateMediator call
+```
+
+### Metrics
+
+Metrics uses the [l2met](https://github.com/ryandotsmith/l2met/wiki/Usage) convention to log `count`, `sample`, `measure`, and `unique` using the `m` helper.  It uses the name set in configuration or it will use "loggerator".  These metrics are sent to `stdout` by default.
+
+```ruby
+m.count(:clicks)                          #=> app=myapp count#myapp.clicks=1
+m.count(:clicks, 2)                       #=> app=myapp count#myapp.clicks=2
+m.sample("database.size", "40.9MB")       #=> app=myapp sample#myapp.database.size=40.9MB
+m.measure("database.query", "200")        #=> app=myapp measure#myapp.database.query=200s
+m.measure("database.query", "200", "ms")  #=> app=myapp measure#myapp.database.query=200ms
+m.unique(users, 244)                      #=> app=myapp unique#myapp.users=244
+```
+
+### Instance & Singleton methods
+
+When you include `Loggerator` modules including `Loggerator::Metrics` and `Loggerator::Namespace`, the methods will be available as both instance methods and singleton methods.
+
+```ruby
+class Foo
+  include Loggerator::Namespace
+  log defining: "class"
+
+  def test
+    log executing: "test"
+  end
+end
+#=> app=myapp ns=Foo defining=class
+
+Foo.new.test
+#=> app=myapp ns=Foo executing=test
+```
+
+## Configuration
+
+There are a few configuration options that can be setup in your initializer.
+
+For any key-values you want on every log message.  With the generated intializer, the app name is the default, but any data can be added to this hash.
+
+```ruby
+Loggerator::Log.default_context = { app: "myapp", env: Rails.env }
+```
+
+You can also provide different streams to use instead of `stdin` and `stderr`
+
+Here's a contrived example:
+```ruby
+$log = StringIO.new
+Loggerator::Log.stdout = $log
+Loggerator::Log.stderr = $log
+```
+
+And you can set the name to use for all your metric logs
+
+```ruby
+Loggerator::Metrics.name = Config.app_name
+```
+
+## Testing
+
+Logs are turned off in your specs, when you add the following near the top of your `spec_helper.rb` or `test_helper.rb`:
+
+```ruby
+require 'loggerator/test'
+```
+
+If you'd like to see them when running your tests, you can force them on with:
+
+```bash
+TEST_LOGS=1 rake
+```
+
+You can also turn the logs off and on programmtically in your tests:
+
+```ruby
+log test1: "turned off"
+Loggerator.turn(:on)
+log test2: "turned on"
+Loggerator.turn(:off)
+log test3: "turned on"
+```
+
+In the prior example, only `test2` would be printed to the log.
+
+To see if the logs are turned on off
+
+```ruby
+Loggerator.turn(:on)
+Loggerator.log?       #=> true
+
+Loggerator.turn(:off)
+Loggerator.log?       #=> false
+```
+

--- a/lib/generators/templates/log.rb.erb
+++ b/lib/generators/templates/log.rb.erb
@@ -1,4 +1,4 @@
-Loggerator.default_context = { app: "<%= app_name %>" }
+Loggerator::Log.default_context = { app: "<%= app_name %>" }
 <% if defined?(Loggerator::Metrics) -%>
 Loggerator::Metrics.name   = "<%= app_name %>"
 <% end -%>

--- a/lib/loggerator/loggerator.rb
+++ b/lib/loggerator/loggerator.rb
@@ -2,14 +2,13 @@ require_relative 'request_store'
 require_relative 'middleware'
 
 module Loggerator
-  extend self
 
   def self.included(mod)
     mod.extend self
   end
 
   def log(data, &block)
-    log_to_stream(stdout, merge_log_contexts(data), &block)
+    Log.to_stream(Log.stdout, Log.contexts(data), &block)
   end
 
   def log_error(e, data = {})
@@ -18,7 +17,7 @@ module Loggerator
     # Log backtrace in reverse order for easier digestion.
     if e.backtrace
       e.backtrace.reverse.each do |backtrace|
-        log_to_stream(stderr, merge_log_contexts(
+        Log.to_stream(Log.stderr, Log.contexts(
           exception_id: exception_id,
           backtrace:    backtrace
         ))
@@ -36,45 +35,28 @@ module Loggerator
 
     data[:status] = e.status if e.respond_to?(:status)
 
-    log_to_stream(stderr, merge_log_contexts(data))
+    Log.to_stream(Log.stderr, Log.contexts(data))
   end
 
   def log_context(data, &block)
-    old = local_context
-    self.local_context = old.merge(data)
+    old = Log.local_context
+    Log.local_context = old.merge(data)
     res = block.call
   ensure
-    self.local_context = old
+    Log.local_context = old
     res
   end
 
-  def default_context=(default_context)
-    @@default_context = default_context
-  end
+  # Don't expose internals into included modules so name-collisions are reduced
+  module Log
+    extend self
 
-  def default_context
-    @@default_context ||= {}
-  end
+    def default_context=(default_context)
+      @@default_context = default_context
+    end
 
-  def stdout=(stream)
-    @@stdout = stream
-  end
-
-  def stdout
-    @@stdout ||= $stdout
-  end
-
-  def stderr=(stream)
-    @@stderr = stream
-  end
-
-  def stderr
-    @@stderr ||= $stderr
-  end
-
-  private
-    def merge_log_contexts(data)
-      default_context.merge(request_context.merge(local_context.merge(data)))
+    def default_context
+      @@default_context ||= {}
     end
 
     def local_context
@@ -85,62 +67,84 @@ module Loggerator
       RequestStore.store[:local_context] = h
     end
 
-    def request_context
-      RequestStore.store[:request_context] || {}
+    def stdout=(stream)
+      @@stdout = stream
     end
 
-    def log_to_stream(stream, data, &block)
+    def stdout
+      @@stdout ||= $stdout
+    end
+
+    def stderr=(stream)
+      @@stderr = stream
+    end
+
+    def stderr
+      @@stderr ||= $stderr
+    end
+
+    def contexts(data)
+      default_context.merge(request_context.merge(local_context.merge(data)))
+    end
+
+    def to_stream(stream, data, &block)
       unless block
         str = unparse(data)
         stream.print(str + "\n")
       else
         data = data.dup
         start = Time.now
-        log_to_stream(stream, data.merge(at: 'start'))
+        to_stream(stream, data.merge(at: 'start'))
         begin
           res = yield
 
-          log_to_stream(stream, data.merge(
+          to_stream(stream, data.merge(
             at: 'finish', elapsed: (Time.now - start).to_f))
           res
         rescue
-          log_to_stream(stream, data.merge(
+          to_stream(stream, data.merge(
             at: 'exception', elapsed: (Time.now - start).to_f))
           raise $!
         end
       end
     end
 
-    def unparse(attrs)
-      attrs.map { |k, v| unparse_pair(k, v) }.compact.join(" ")
-    end
-
-    def unparse_pair(k, v)
-      v = v.call if v.is_a?(Proc)
-      # only quote strings if they include whitespace
-      if v == nil
-        nil
-      elsif v == true
-        k
-      elsif v.is_a?(Float)
-        "#{k}=#{format("%.3f", v)}"
-      elsif v.is_a?(String) && v =~ /\s/
-        quote_string(k, v)
-      elsif v.is_a?(Time)
-        "#{k}=#{v.iso8601}"
-      else
-        "#{k}=#{v}"
+    private
+      def request_context
+        RequestStore.store[:request_context] || {}
       end
-    end
 
-    def quote_string(k, v)
-      # try to find a quote style that fits
-      if !v.include?('"')
-        %{#{k}="#{v}"}
-      elsif !v.include?("'")
-        %{#{k}='#{v}'}
-      else
-        %{#{k}="#{v.gsub(/"/, '\\"')}"}
+      def unparse(attrs)
+        attrs.map { |k, v| unparse_pair(k, v) }.compact.join(" ")
       end
-    end
+
+      def unparse_pair(k, v)
+        v = v.call if v.is_a?(Proc)
+        # only quote strings if they include whitespace
+        if v == nil
+          nil
+        elsif v == true
+          k
+        elsif v.is_a?(Float)
+          "#{k}=#{format("%.3f", v)}"
+        elsif v.is_a?(String) && v =~ /\s/
+          quote_string(k, v)
+        elsif v.is_a?(Time)
+          "#{k}=#{v.iso8601}"
+        else
+          "#{k}=#{v}"
+        end
+      end
+
+      def quote_string(k, v)
+        # try to find a quote style that fits
+        if !v.include?('"')
+          %{#{k}="#{v}"}
+        elsif !v.include?("'")
+          %{#{k}='#{v}'}
+        else
+          %{#{k}="#{v.gsub(/"/, '\\"')}"}
+        end
+      end
+  end
 end

--- a/lib/loggerator/metrics.rb
+++ b/lib/loggerator/metrics.rb
@@ -7,6 +7,10 @@ module Loggerator
 
     @@metrics_name = 'loggerator'
 
+    def self.included(mod)
+      mod.extend self
+    end
+
     def name=(name)
       @@metrics_name = name
     end
@@ -30,7 +34,6 @@ module Loggerator
     def measure(key, value, units='s')
       log("measure##{name}.#{key}" => "#{value}#{units}")
     end
-
   end
 
   # included Metrics shortcut

--- a/lib/loggerator/metrics.rb
+++ b/lib/loggerator/metrics.rb
@@ -7,10 +7,6 @@ module Loggerator
 
     @@metrics_name = 'loggerator'
 
-    def self.included(mod)
-      mod.extend self
-    end
-
     def name=(name)
       @@metrics_name = name
     end

--- a/lib/loggerator/namespace.rb
+++ b/lib/loggerator/namespace.rb
@@ -4,19 +4,25 @@ module Loggerator
   module Namespace
     include Loggerator
 
-    def log(data={}, &blk)
-      log_namespace!
-      super
+    def self.included(mod)
+      mod.extend self
+    end
+
+    def log(data={}, &block)
+      log_namespace! do
+        super
+      end
     end
 
     def log_error(e, data={})
-      log_namespace!
-      super
+      log_namespace! do
+        super
+      end
     end
 
     private
-      def log_namespace!
-        self.local_context = { ns: self.class.name }
+      def log_namespace!(&block)
+        log_context({ns: kind_of?(Module) ? name : self.class.name }, &block)
       end
   end
 end


### PR DESCRIPTION
Added a README, which in turn sussed out some bugs and fixes.

They are:
- Moving much of the logging internals to the `Loggerator::Log` module to reduce the name collisions when including `Loggerator`
- Ensure that metrics helper is available as a singleton method
- Ensure that namespace additions to log helpers are available as singleton methods
- Fixed namespace to not clobber existing `log_context`

Items still needed from #1 now are:
- `loggerator/sinatra` include loggerator into Sinatra apps
- write and update tests

/cc @joshuatobin @lexelby 