### PR TITLE
disable Rails::Rack::Logger as part of railties

### DIFF
--- a/lib/loggerator/railtie/adapter.rb
+++ b/lib/loggerator/railtie/adapter.rb
@@ -4,6 +4,8 @@ module Loggerator
       config.before_configuration do
         Rails.application.middleware.insert_after ActionDispatch::RequestId, Loggerator::Middleware::RequestStore
         Rails.application.middleware.swap         ActionDispatch::RequestId, Loggerator::Middleware::RequestID
+
+        Rails.application.middleware.delete(Rails::Rack::Logger) if defined?(Rails::Rack::Logger)
       end
 
       config.before_initialize do

--- a/loggerator.gemspec
+++ b/loggerator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "loggerator"
-  s.version     = "0.1.1"
+  s.version     = "0.1.2"
   s.summary     = "loggerator: A Log Helper"
   s.description = "Simple web application extension for logging, following the 12factor pattern."
   s.authors     = ["Joshua Mervine", "Reid MacDonald"]

--- a/test/loggerator/rails_test.rb
+++ b/test/loggerator/rails_test.rb
@@ -8,7 +8,9 @@ class TestLoggeratorRails < Minitest::Test
 
     assert middlewares.include?(Loggerator::Middleware::RequestStore)
     assert middlewares.include?(Loggerator::Middleware::RequestID)
+
     refute middlewares.include?(ActionDispatch::RequestId)
+    refute middlewares.include?(Rails::Rack::Logger)
   end
 
   def test_loggerator_included


### PR DESCRIPTION
@reidmix 

Possible next step would be to separate `Loggerator::Railtie::Adapter` in to action groupings, e.g. `MiddlewareAdapter` and `LoggeratorAdapter` to allow for more fine grained configuration.